### PR TITLE
OAuth2 로그인 기능 구현

### DIFF
--- a/airdnb/build.gradle
+++ b/airdnb/build.gradle
@@ -27,6 +27,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security:'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 	compileOnly 'org.projectlombok:lombok'

--- a/airdnb/src/main/java/com/example/airdnb/config/CustomAuthenticationSuccessHandler.java
+++ b/airdnb/src/main/java/com/example/airdnb/config/CustomAuthenticationSuccessHandler.java
@@ -1,0 +1,43 @@
+package com.example.airdnb.config;
+
+import com.example.airdnb.domain.user.User;
+import com.example.airdnb.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private static final String REDIRECT_PATH = "http://localhost:8081/login-success";
+    private final TokenProvider tokenProvider;
+    private final UserRepository userRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+        Authentication authentication) throws IOException {
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        User user = userRepository.findByEmail(oAuth2User.getAttribute("email"))
+            .orElseThrow(() -> new NoSuchElementException("User not found"));
+        String accessToken = tokenProvider.generateToken(user);
+        String targetUrl = getTargetUrl(accessToken);
+
+        clearAuthenticationAttributes(request);
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+
+    private String getTargetUrl(String token) {
+        return UriComponentsBuilder.fromUriString(REDIRECT_PATH)
+            .queryParam("token", token)
+            .build()
+            .toUriString();
+    }
+}

--- a/airdnb/src/main/java/com/example/airdnb/config/SecurityConfig.java
+++ b/airdnb/src/main/java/com/example/airdnb/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.airdnb.config;
 
+import com.example.airdnb.config.oauth.CustomAuthenticationEntryPoint;
 import com.example.airdnb.config.oauth.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -26,6 +27,7 @@ public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
     private final CustomAuthenticationSuccessHandler customAuthenticationSuccessHandler;
     private final TokenAuthenticationFilter tokenAuthenticationFilter;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -49,7 +51,10 @@ public class SecurityConfig {
                     .userInfoEndpoint(userInfoEndpointConfig ->
                         userInfoEndpointConfig.userService(customOAuth2UserService))
                     .successHandler(customAuthenticationSuccessHandler)
-            );
+            )
+            .exceptionHandling(
+                httpSecurityExceptionHandlingConfigurer -> httpSecurityExceptionHandlingConfigurer.authenticationEntryPoint(
+                    customAuthenticationEntryPoint));
 
         return http.build();
     }

--- a/airdnb/src/main/java/com/example/airdnb/config/TokenProvider.java
+++ b/airdnb/src/main/java/com/example/airdnb/config/TokenProvider.java
@@ -45,7 +45,7 @@ public class TokenProvider {
             .expiration(new Date(new Date().getTime() + expirationTime))
             .subject(user.getEmail())
             .claim("id", user.getId())
-            .claim("role", user.getRole())
+            .claim("role", user.getKey())
             .signWith(key)
             .compact();
     }
@@ -58,7 +58,7 @@ public class TokenProvider {
                 .parseSignedClaims(token);
             log.debug("검증 성공");
             return true;
-        } catch (JwtException e) {
+        } catch (JwtException | IllegalArgumentException e) {
             log.debug("검증 실패");
             return false;
         }
@@ -84,7 +84,7 @@ public class TokenProvider {
             .build()
             .parseSignedClaims(token)
             .getPayload();
-        
+
     }
 
 }

--- a/airdnb/src/main/java/com/example/airdnb/config/WebConfig.java
+++ b/airdnb/src/main/java/com/example/airdnb/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.example.airdnb.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+            .allowedOrigins("http://localhost:8081") // Vue.js 서버 주소
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+            .allowedHeaders("*")
+            .allowCredentials(true);
+    }
+}

--- a/airdnb/src/main/java/com/example/airdnb/config/oauth/CustomAuthenticationEntryPoint.java
+++ b/airdnb/src/main/java/com/example/airdnb/config/oauth/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,20 @@
+package com.example.airdnb.config.oauth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        response.setContentType("application/json");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getOutputStream().println("{ \"error\": \"Unauthorized\", \"message\": \"" + authException.getMessage() + "\" }");
+    }
+}

--- a/airdnb/src/main/java/com/example/airdnb/config/oauth/CustomOAuth2UserService.java
+++ b/airdnb/src/main/java/com/example/airdnb/config/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,39 @@
+package com.example.airdnb.config.oauth;
+
+import com.example.airdnb.domain.user.Role;
+import com.example.airdnb.domain.user.User;
+import com.example.airdnb.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        saveOrUpdate(oAuth2User);
+        return oAuth2User;
+    }
+
+    private void saveOrUpdate(OAuth2User oAuth2User) {
+        String email = oAuth2User.getAttribute("email");
+        String name = oAuth2User.getAttribute("name");
+
+        User user = userRepository.findByEmail(email).orElseGet(() ->
+            User.builder()
+                .email(email)
+                .name(name)
+                .role(Role.GUEST)
+                .build());
+
+        userRepository.save(user);
+    }
+}

--- a/airdnb/src/main/java/com/example/airdnb/controller/ReviewController.java
+++ b/airdnb/src/main/java/com/example/airdnb/controller/ReviewController.java
@@ -1,0 +1,10 @@
+package com.example.airdnb.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/reviews")
+public class ReviewController {
+
+}

--- a/airdnb/src/main/java/com/example/airdnb/domain/user/Role.java
+++ b/airdnb/src/main/java/com/example/airdnb/domain/user/Role.java
@@ -1,0 +1,15 @@
+package com.example.airdnb.domain.user;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    HOST("ROLE_HOST"),
+    GUEST("ROLE_GUEST"),
+    ADMIN("ROLE_ADMIN");
+
+    private final String key;
+
+}

--- a/airdnb/src/main/java/com/example/airdnb/domain/user/User.java
+++ b/airdnb/src/main/java/com/example/airdnb/domain/user/User.java
@@ -37,7 +37,6 @@ public class User {
     @Column(nullable = false, unique = true)
     private String email;
 
-    @Column(nullable = false)
     private String password;
 
     @Column(nullable = false)
@@ -73,7 +72,12 @@ public class User {
         this.name = name;
     }
 
-    public enum Role {
-        HOST, GUEST, ADMIN
+    public String getKey() {
+        return role.getKey();
+    }
+
+    public User updateName(String name) {
+        this.name = name;
+        return this;
     }
 }

--- a/airdnb/src/main/java/com/example/airdnb/dto/user/UserCreateRequest.java
+++ b/airdnb/src/main/java/com/example/airdnb/dto/user/UserCreateRequest.java
@@ -1,7 +1,7 @@
 package com.example.airdnb.dto.user;
 
 import com.example.airdnb.domain.user.User;
-import com.example.airdnb.domain.user.User.Role;
+import com.example.airdnb.domain.user.Role;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/airdnb/src/main/java/com/example/airdnb/dto/user/UserResponse.java
+++ b/airdnb/src/main/java/com/example/airdnb/dto/user/UserResponse.java
@@ -1,13 +1,7 @@
 package com.example.airdnb.dto.user;
 
+import com.example.airdnb.domain.user.Role;
 import com.example.airdnb.domain.user.User;
-import com.example.airdnb.domain.user.User.Role;
-import jakarta.persistence.Column;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 
 public record UserResponse(
     Long id,

--- a/airdnb/src/main/java/com/example/airdnb/service/AccommodationService.java
+++ b/airdnb/src/main/java/com/example/airdnb/service/AccommodationService.java
@@ -2,7 +2,7 @@ package com.example.airdnb.service;
 
 import com.example.airdnb.domain.accommodation.Accommodation;
 import com.example.airdnb.domain.user.User;
-import com.example.airdnb.domain.user.User.Role;
+import com.example.airdnb.domain.user.Role;
 import com.example.airdnb.dto.accommodation.AccommodationCreationRequest;
 import com.example.airdnb.dto.accommodation.AccommodationResponse;
 import com.example.airdnb.repository.AccommodationRepository;

--- a/airdnb/src/main/java/com/example/airdnb/service/UserService.java
+++ b/airdnb/src/main/java/com/example/airdnb/service/UserService.java
@@ -48,4 +48,8 @@ public class UserService {
         String token = tokenProvider.generateToken(user);
         return LoginResponse.from(user, token);
     }
+
+    public User findByEmail(String email) {
+        return userRepository.findByEmail(email).orElseThrow(NoSuchElementException::new);
+    }
 }


### PR DESCRIPTION
## 구현 기능
- OAuth 로그인 기능 추가 (`/oauth2/authorization/google`)
- OAuth 승인 시 이메일, 이름, 역할(GUEST) 를 DB에 저장
- OAuth 로그인 시 JWT 토큰을 쿼리 파라미터에 추가해 로그인 성공 페이지로 리다이렉트
  ```
  http://localhost:8081/login-success?token={token}
  ```
- 인증되지 않은 사용자의 경우 UN_AUTHORIZATION을 반환해 프론트엔드에서 처리하도록 구현